### PR TITLE
Update Verify.Nupkg version

### DIFF
--- a/test/PackageTests/PackageTests.csproj
+++ b/test/PackageTests/PackageTests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Verify.Nupkg" Version="1.0.15" />
+    <PackageReference Include="Verify.Nupkg" Version="1.0.16" />
     <PackageReference Include="Verify.Xunit" Version="23.5.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">

--- a/test/PackageTests/snapshots/Baselines.Match#manifest.verified.nuspec
+++ b/test/PackageTests/snapshots/Baselines.Match#manifest.verified.nuspec
@@ -1,4 +1,4 @@
-﻿<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>GetPackFromProject</id>
     <version>********</version>


### PR DESCRIPTION
Update `Verify.Nupkg` to the latest version to pick up the fix for Nuspec schema scrubbing.