### PR TITLE
Update tests to validate ArtifactsPath outputs

### DIFF
--- a/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
+++ b/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Build.Utilities.ProjectCreation;
+﻿using Microsoft.Build.Evaluation;
+using Microsoft.Build.Utilities.ProjectCreation;
 
 namespace GetPackFromProject.IntegrationTests;
 
 internal static class ProjectCreatorTemplatesExtensions
 {
-    public static ProjectCreator ProjectThatProducesAPackage(this ProjectCreatorTemplates templates, bool generatePackageOnBuild, string[] targetFrameworks)
+    public static ProjectCreator ProjectThatProducesAPackage(this ProjectCreatorTemplates templates, string[] targetFrameworks, bool generatePackageOnBuild)
     {
         ProjectCreator project = templates
             .SdkCsproj(targetFrameworks)
@@ -18,11 +19,27 @@ internal static class ProjectCreatorTemplatesExtensions
         return project;
     }
 
-    public static ProjectCreator MainProject(this ProjectCreatorTemplates templates, string[] targetFrameworks, Package package, bool useArtifactsOutput)
+    public static ProjectCreator MainProject(this ProjectCreatorTemplates templates, string[] targetFrameworks, Package package)
     {
-        return templates
+        ProjectCreator project = templates
             .SdkCsproj(targetFrameworks)
-            .Property("UseArtifactsOutput", useArtifactsOutput.ToString().ToLowerInvariant())
             .ItemPackageReference(package);
+
+        return project;
     }
+
+    public static ProjectCreator DirectoryBuildProps(this ProjectCreatorTemplates templates, DirectoryInfo directory, bool useArtifactsOutput)
+    {
+        ProjectCreator project = ProjectCreator.Create(
+                    path: Path.Combine(directory.FullName, "Directory.Build.props"),
+                    projectFileOptions: NewProjectFileOptions.None);
+
+        if (useArtifactsOutput)
+        {
+            project.Property("UseArtifactsOutput", "true");
+        }
+
+        return project.Save();
+    }
+
 }

--- a/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
+++ b/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
@@ -5,7 +5,7 @@ namespace GetPackFromProject.IntegrationTests;
 
 internal static class ProjectCreatorTemplatesExtensions
 {
-    public static ProjectCreator ProjectThatProducesAPackage(this ProjectCreatorTemplates templates, string[] targetFrameworks, bool generatePackageOnBuild)
+    public static ProjectCreator ProjectThatProducesAPackage(this ProjectCreatorTemplates templates, DirectoryInfo directory, string[] targetFrameworks, bool generatePackageOnBuild)
     {
         ProjectCreator project = templates
             .SdkCsproj(targetFrameworks)
@@ -15,6 +15,8 @@ internal static class ProjectCreatorTemplatesExtensions
         {
             project.Property("GeneratePackageOnBuild", "true");
         }
+
+        project.Save(Path.Combine(directory.FullName, "Leaf", "Leaf.csproj"));
 
         return project;
     }

--- a/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
+++ b/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
@@ -21,11 +21,12 @@ internal static class ProjectCreatorTemplatesExtensions
         return project;
     }
 
-    public static ProjectCreator MainProject(this ProjectCreatorTemplates templates, string[] targetFrameworks, Package package)
+    public static ProjectCreator MainProject(this ProjectCreatorTemplates templates, DirectoryInfo directory, string[] targetFrameworks, Package package)
     {
         ProjectCreator project = templates
             .SdkCsproj(targetFrameworks)
-            .ItemPackageReference(package);
+            .ItemPackageReference(package)
+            .Save(Path.Combine(directory.FullName, "Sample", $"Sample.csproj"));
 
         return project;
     }

--- a/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
+++ b/test/IntegrationTests/ProjectCreatorTemplatesExtensions.cs
@@ -17,4 +17,12 @@ internal static class ProjectCreatorTemplatesExtensions
 
         return project;
     }
+
+    public static ProjectCreator MainProject(this ProjectCreatorTemplates templates, string[] targetFrameworks, Package package, bool useArtifactsOutput)
+    {
+        return templates
+            .SdkCsproj(targetFrameworks)
+            .Property("UseArtifactsOutput", useArtifactsOutput.ToString().ToLowerInvariant())
+            .ItemPackageReference(package);
+    }
 }

--- a/test/IntegrationTests/Tests.cs
+++ b/test/IntegrationTests/Tests.cs
@@ -48,7 +48,7 @@ public class GivenAProjectWithAProjectReference: TestBase
         {
             ProjectCreator.Templates.DirectoryBuildProps(Temp, useArtifactsOutput);
 
-            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(leafTfms, generatePackageOnBuild: false).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
+            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: false);
 
             ProjectCreator main = ProjectCreator.Templates
                 .MainProject(mainTfms, package)
@@ -79,7 +79,7 @@ public class GivenAProjectWithAProjectReference: TestBase
         {
             ProjectCreator.Templates.DirectoryBuildProps(Temp, useArtifactsOutput);
 
-            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(leafTfms, generatePackageOnBuild: false).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
+            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: false);
 
             ProjectCreator.Templates
                 .MainProject(mainTfms, package)
@@ -108,7 +108,7 @@ public class GivenAProjectWithAProjectReference: TestBase
         {
             ProjectCreator.Templates.DirectoryBuildProps(Temp, useArtifactsOutput);
 
-            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(leafTfms, generatePackageOnBuild: false).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
+            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: false);
 
             ProjectCreator.Templates
                 .MainProject(mainTfms, package)
@@ -136,7 +136,7 @@ public class GivenAProjectWithAProjectReference: TestBase
         {
             ProjectCreator.Templates.DirectoryBuildProps(Temp, useArtifactsOutput);
 
-            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(leafTfms, generatePackageOnBuild: true).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
+            ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: true);
 
             ProjectCreator main = ProjectCreator.Templates
                 .MainProject(mainTfms, package)

--- a/test/IntegrationTests/Tests.cs
+++ b/test/IntegrationTests/Tests.cs
@@ -51,13 +51,13 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: false);
 
             ProjectCreator main = ProjectCreator.Templates
-                .MainProject(mainTfms, package)
+                .MainProject(Temp, mainTfms, package)
                 .Property("GetPackFromProject_CopyToOutputDirectory", "Never")
                 .ItemProjectReference(leafProject, metadata: new Dictionary<string, string?>
                 {
                     { "AddPackageAsOutput", "true" }
                 })
-                .Save(Path.Combine(Temp.FullName, "Sample", $"Sample.csproj"));
+                .Save();
 
             main.TryBuild(restore: true, target: "Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult>? outputs);
 
@@ -82,13 +82,13 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: false);
 
             ProjectCreator.Templates
-                .MainProject(mainTfms, package)
+                .MainProject(Temp, mainTfms, package)
                 .ItemProjectReference(leafProject, metadata: new Dictionary<string, string?>
                 {
                     { "AddPackageAsOutput", "true" }
                 })
                 .Property("MSBuildTreatWarningsAsErrors", "true")
-                .Save(Path.Combine(Temp.FullName, "Sample", $"Sample.csproj"))
+                .Save()
                 .TryBuild(restore: true, target: "Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult>? outputs);
 
             buildOutput.ErrorEvents.Should()
@@ -111,9 +111,9 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: false);
 
             ProjectCreator.Templates
-                .MainProject(mainTfms, package)
+                .MainProject(Temp, mainTfms, package)
                 .ItemProjectReference(leafProject)
-                .Save(Path.Combine(Temp.FullName, "Sample", $"Sample.csproj"))
+                .Save()
                 .TryBuild(restore: true, target: "Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult>? outputs);
 
             buildOutput.ErrorEvents.Should().BeEmpty();
@@ -139,7 +139,7 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(Temp, leafTfms, generatePackageOnBuild: true);
 
             ProjectCreator main = ProjectCreator.Templates
-                .MainProject(mainTfms, package)
+                .MainProject(Temp, mainTfms, package)
                 .ItemProjectReference(leafProject, metadata: new Dictionary<string, string?>
                 {
                     { "AddPackageAsOutput", "true" }
@@ -160,7 +160,7 @@ public class GivenAProjectWithAProjectReference: TestBase
                         { "Text", $"{projectMetadata}%(ProjectReference.PackageOutputs)" },
                         { "Importance", "High" }
                     })
-                .Save(Path.Combine(Temp.FullName, "Sample", $"Sample.csproj"));
+                .Save();
 
             main.TryBuild(restore: true, target: "Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult>? outputs);
 

--- a/test/IntegrationTests/Tests.cs
+++ b/test/IntegrationTests/Tests.cs
@@ -189,35 +189,22 @@ public class GivenAProjectWithAProjectReference: TestBase
 
     private static string GenerateMainPackageDirectory(DirectoryInfo directory, bool useArtifactsOutput)
     {
-        if (useArtifactsOutput)
-        {
-            return Path.Combine(directory.FullName, "artifacts", "bin", "Sample");
-        }
-
-        return Path.Combine(directory.FullName, "Sample", "bin", "Debug");
+        return useArtifactsOutput
+            ? Path.Combine(directory.FullName, "artifacts", "bin", "Sample")
+            : Path.Combine(directory.FullName, "Sample", "bin", "Debug");
     }
 
     private static string GenerateLeafNupkgPath(bool useArtifactsOutput, DirectoryInfo directory)
     {
-        char sep = Path.DirectorySeparatorChar;
-
-        if (useArtifactsOutput)
-        {
-            return $"{directory.FullName}{sep}artifacts{sep}package{sep}debug{sep}Leaf.1.0.0-deadbeef.nupkg";
-        }
-
-        return $"{directory.FullName}{sep}Leaf{sep}bin{sep}Debug{sep}Leaf.1.0.0-deadbeef.nupkg";
+        return useArtifactsOutput
+            ? Path.Combine(directory.FullName, "artifacts", "package", "debug", "Leaf.1.0.0-deadbeef.nupkg")
+            : Path.Combine(directory.FullName, "Leaf", "bin", "Debug", "Leaf.1.0.0-deadbeef.nupkg");
     }
 
     private static string GenerateLeafNuspecPath(bool useArtifactsOutput, DirectoryInfo directory)
     {
-        char sep = Path.DirectorySeparatorChar;
-
-        if (useArtifactsOutput)
-        {
-            return $"{directory.FullName}{sep}artifacts{sep}obj{sep}Leaf{sep}Debug{sep}Leaf.1.0.0-deadbeef.nuspec";
-        }
-
-        return $"{directory.FullName}{sep}Leaf{sep}obj{sep}Debug{sep}Leaf.1.0.0-deadbeef.nuspec";
+        return useArtifactsOutput
+            ? Path.Combine(directory.FullName, "artifacts", "obj", "Leaf", "Debug", "Leaf.1.0.0-deadbeef.nuspec")
+            : Path.Combine(directory.FullName, "Leaf", "obj", "Debug", "Leaf.1.0.0-deadbeef.nuspec");
     }
 }

--- a/test/IntegrationTests/Tests.cs
+++ b/test/IntegrationTests/Tests.cs
@@ -46,9 +46,8 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(generatePackageOnBuild: false, leafTfms).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
 
             ProjectCreator main = ProjectCreator.Templates
-                .SdkCsproj(mainTfms)
+                .MainProject(mainTfms, package, useArtifactsOutput: false)
                 .Property("GetPackFromProject_CopyToOutputDirectory", "Never")
-                .ItemPackageReference(package)
                 .ItemProjectReference(leafProject, metadata: new Dictionary<string, string?>
                 {
                     { "AddPackageAsOutput", "true" }
@@ -76,8 +75,7 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(generatePackageOnBuild: false, leafTfms).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
 
             ProjectCreator.Templates
-                .SdkCsproj(mainTfms)
-                .ItemPackageReference(package)
+                .MainProject(mainTfms, package, useArtifactsOutput: false)
                 .ItemProjectReference(leafProject, metadata: new Dictionary<string, string?>
                 {
                     { "AddPackageAsOutput", "true" }
@@ -104,8 +102,7 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(generatePackageOnBuild: false, leafTfms).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
 
             ProjectCreator.Templates
-                .SdkCsproj(mainTfms)
-                .ItemPackageReference(package)
+                .MainProject(mainTfms, package, useArtifactsOutput: false)
                 .ItemProjectReference(leafProject)
                 .Save(Path.Combine(Temp.FullName, "Sample", $"Sample.csproj"))
                 .TryBuild(restore: true, target: "Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult>? outputs);
@@ -132,8 +129,7 @@ public class GivenAProjectWithAProjectReference: TestBase
             ProjectCreator leafProject = ProjectCreator.Templates.ProjectThatProducesAPackage(generatePackageOnBuild: true, leafTfms).Save(Path.Combine(Temp.FullName, "Leaf", "Leaf.csproj"));
 
             ProjectCreator main = ProjectCreator.Templates
-                .SdkCsproj(mainTfms)
-                .ItemPackageReference(package)
+                .MainProject(mainTfms, package, useArtifactsOutput: false)
                 .ItemProjectReference(leafProject, metadata: new Dictionary<string, string?>
                 {
                     { "AddPackageAsOutput", "true" }


### PR DESCRIPTION
Update tests to also verify correct behavior when using .NET 8's ArtifactsPath. Actual behavior was correct, but tests required refactoring.