### PR TITLE
Also call Pack in GetPackFromProject_PackFor*

### DIFF
--- a/src/ValidateGeneratePackageOnBuild/build/GetPackFromProject.targets
+++ b/src/ValidateGeneratePackageOnBuild/build/GetPackFromProject.targets
@@ -26,20 +26,20 @@
     Condition="'$(GetPackFromProject_IsOuterBuild)' == 'true'">
 
     <!--
-      Pack is an outer-build target, thus when the leaf is crosstargeting / multi-targeting
+      Pack is an outer build target, thus when the leaf is crosstargeting / multi-targeting
       we need to call Pack ourselves.
 
       TODO: This does more work than necessary when leaf is single-targeting.
 
-      Since the referencing project is multi-targeting, call build now to avoid races /
-      locked files trying to build twice during inner builds.
+      Since the referencing project is multi-targeting, pack before dispatching to inner builds
+      to avoid races / locked files trying to build twice during inner builds.
     -->
 
     <!--
-      Use the 'Build' target and not 'Pack' because the project may not be built yet, and Pack doesn't ensure a
+      Target 'Build' and 'Pack' because the project may not be built yet and Pack doesn't ensure a
       build like `dotnet build` does.
     -->
-    <MSBuild Projects="%(_ProjectsToCopy.Identity)" Targets="Build" />
+    <MSBuild Projects="%(_ProjectsToCopy.Identity)" Targets="Build;Pack" />
   </Target>
 
   <Target
@@ -47,23 +47,23 @@
     DependsOnTargets="GetPackFromProject_CollectProjectReferences"
     Condition="'$(GetPackFromProject_IsMultiTargeted)' != 'true'">
     <!--
-      Pack is an outer-build target, thus when the leaf is crosstargeting / multi-targeting
+      Pack is an outer build target, thus when the leaf is crosstargeting / multi-targeting
       we need to call Pack ourselves.
 
       TODO: This does more work than necessary when leaf is single-targeting.
 
-      Since the referencing project is single-targeting, call build now.
+      Since the referencing project is single-targeting, pack can happen whenever needed.
     -->
 
     <!--
-      Use the 'Build' target and not 'Pack' because the project may not be built yet, and Pack doesn't ensure a
+      Target 'Build' and 'Pack' because the project may not be built yet and Pack doesn't ensure a
       build like `dotnet build` does.
     -->
-    <MSBuild Projects="%(_ProjectsToCopy.Identity)" Targets="Build" />
+    <MSBuild Projects="%(_ProjectsToCopy.Identity)" Targets="Build;Pack" />
   </Target>
 
   <Target
-    Name="AddProjectPackagesAsOutput"
+    Name="GetPackFromProject_AddProjectPackagesAsOutput"
     DependsOnTargets="GetPackFromProject_CollectProjectReferences;GetPackFromProject_PackForSingleTarget"
     BeforeTargets="AssignTargetPaths">
 


### PR DESCRIPTION
The GetPackFromProject_PackFor* targets were calling `Build` on the leaf project and assuming that both `Build` and `Pack` would be done (relying on `GeneratePackageOnBuild` to do the heavy lifting). It appears that was never a safe assumption to make, but the race seemed to reliably work out that way.

With .NET 9 SDKs, it appears that we're now sometimes losing the race. The leaf project builds, returning control to PackFor*, and then the referencing project builds assuming the .nupkg is already available. However, the referencing build completes before the leaf Pack completes, and thus the copy to output directory fails, resulting in an error like this:

> Error Could not copy the file "D:\a\moq.analyzers\moq.analyzers\artifacts\package\release\Moq.Analyzers.0.3.0-alpha-ge454d76cff.nupkg" because it was not found.

The fix is to explicitly call Pack as well to ensure its complete before continuing.