### PR TITLE
Update SDK to .NET 9

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.6.133",
+      "version": "3.6.146",
       "commands": [
         "nbgv"
       ]

--- a/build/targets/CodeAnalysis.props
+++ b/build/targets/CodeAnalysis.props
@@ -4,6 +4,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!--
+      Setting audit to direct only because as a lib (as opposed to an app)
+      we need to be permissive for compatibility; it's the app's responsibility
+      to reify the dependency tree.
+    -->
+    <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>
 
 </Project>

--- a/build/targets/ReproducibleBuilds.props
+++ b/build/targets/ReproducibleBuilds.props
@@ -1,10 +1,9 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
   </ItemGroup>
 
-  <!-- TODO: Re-enable once https://github.com/dotnet/reproducible-builds/pull/33 is addressed -->
-  <!-- <Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="1.1.1" /> -->
+  <Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
 
 </Project>

--- a/build/targets/TestProjects.props
+++ b/build/targets/TestProjects.props
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <ArtifactsTestResultsPath>$(RepoRoot)/artifacts/TestResults</ArtifactsTestResultsPath>
+
+    <!--
+      Defer adoption of the Microsoft Testing Platform for now.
+
+      See https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro?tabs=dotnetcli)
+    -->
+    <UseVSTest>true</UseVSTest>
   </PropertyGroup>
 
 </Project>

--- a/build/targets/TestProjects.targets
+++ b/build/targets/TestProjects.targets
@@ -4,6 +4,7 @@
 
       <PropertyGroup>
         <!-- Enable test logging to TRX files and place them in the artifacts directory -->
+        <!-- TODO: When https://github.com/microsoft/vstest/issues/5132 ships, suppress overwrite warning -->
         <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
         <VSTestResultsDirectory Condition="'$(VSTestResultsDirectory)' == ''">$(ArtifactsTestResultsPath)/$(TargetFramework)</VSTestResultsDirectory>
       </PropertyGroup>

--- a/build/targets/Versioning.props
+++ b/build/targets/Versioning.props
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>
-      <Version>3.6.133</Version>
+      <Version>3.6.146</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.101",
-    "rollForward": "latestFeature"
+    "version": "9.0.100",
+    "rollForward": "feature"
   },
   "msbuild-sdks": {
       "Microsoft.Build.NoTargets" : "3.7.56"

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "feature"
   },
   "msbuild-sdks": {
-      "Microsoft.Build.NoTargets" : "3.7.56"
+      "MSTest.Sdk": "3.6.3"
   }
 }

--- a/src/ValidateGeneratePackageOnBuild/ValidateGeneratePackageOnBuild.csproj
+++ b/src/ValidateGeneratePackageOnBuild/ValidateGeneratePackageOnBuild.csproj
@@ -24,7 +24,7 @@
 
   <PropertyGroup>
     <!-- TODO: Extract these into an MSBuild task SDK -->
-    <!-- TODO: Make an ItemGroupDefintion to mark everything as PrivateAssets="All" -->
+    <!-- TODO: Make an ItemGroupDefinition to mark everything as PrivateAssets="All" -->
     <!-- TODO: Add ExcludeAssets="runtime" for MSBuild assemblies: https://github.com/microsoft/MSBuildLocator/blob/198e001f14230163ea5d992fdc1dbaf256139dbc/src/MSBuildLocator/build/Microsoft.Build.Locator.targets#L2 -->
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <GenerateDependencyFile>true</GenerateDependencyFile>

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -11,10 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="MSTest" Version="3.3.1" />
-    <PackageReference Include="MSBuild.ProjectCreation" Version="12.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="MSTest" Version="3.6.3" />
+    <PackageReference Include="MSBuild.ProjectCreation" Version="14.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <!-- Limit .NET Framework tests to Windows build / test machines -->
@@ -11,12 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="MSTest" Version="3.6.3" />
     <PackageReference Include="MSBuild.ProjectCreation" Version="14.0.0" />
   </ItemGroup>
 

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Limit .NET Framework tests to Windows build / test machines -->
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net8.0;net9.0</TargetFrameworks>
     <RootNamespace>GetPackFromProject.IntegrationTests</RootNamespace>
     <AssemblyName>$(RootNamespace)</AssemblyName>
     <IsPackable>false</IsPackable>

--- a/test/PackageTests/Baselines.cs
+++ b/test/PackageTests/Baselines.cs
@@ -5,8 +5,6 @@ namespace GetPackFromProject.PackageTests;
 [TestClass]
 public partial class Baselines
 {
-    private static readonly VerifySettings VerifySettings = new VerifySettings().ScrubNuspec();
-
     [TestMethod]
     public Task Match()
     {
@@ -14,7 +12,7 @@ public partial class Baselines
 
         FileInfo package = workingDirectory.GetFiles("GetPackFromProject.*.nupkg").OrderByDescending(f => f.LastWriteTimeUtc).First();
 
-        return VerifyFile(package, VerifySettings);
+        return VerifyFile(package).ScrubNuspec();
     }
 
     private DirectoryInfo GetWorkingDirectory()

--- a/test/PackageTests/PackageTests.csproj
+++ b/test/PackageTests/PackageTests.csproj
@@ -13,9 +13,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSTest" Version="3.3.1" />
-    <PackageReference Include="Verify.Nupkg" Version="1.1.1" />
-    <PackageReference Include="Verify.MSTest" Version="24.3.0-beta.4" /><!-- Validating new MSTest source generator -->
+    <PackageReference Include="MSTest" Version="3.6.3" />
+    <PackageReference Include="Verify.Nupkg" Version="1.1.6" />
+    <PackageReference Include="Verify.MSTest" Version="28.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PackageTests/PackageTests.csproj
+++ b/test/PackageTests/PackageTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -9,11 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MSTest" Version="3.6.3" />
     <PackageReference Include="Verify.Nupkg" Version="1.1.6" />
     <PackageReference Include="Verify.MSTest" Version="28.3.2" />
   </ItemGroup>

--- a/test/PackageTests/PackageTests.csproj
+++ b/test/PackageTests/PackageTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>GetPackFromProject.PackageTests</RootNamespace>
     <AssemblyName>$(RootNamespace)</AssemblyName>
     <IsPackable>false</IsPackable>

--- a/test/PackageTests/snapshots/Baselines.Match#manifest.verified.nuspec
+++ b/test/PackageTests/snapshots/Baselines.Match#manifest.verified.nuspec
@@ -12,6 +12,6 @@
     <description>An MSBuild task helper to simplify testing NuGet packages by automatically ensuring the latest package is built and placed in the output directory for test projects.</description>
     <copyright>Copyright 2024. All rights reserved</copyright>
     <tags>NuGet, MSBuild</tags>
-    <repository type="git" url="https://github.com/MattKotsenas/GetPackFromProject.git" branch="refs/heads/refactor/dotnet-9" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/GetPackFromProject.git" branch="********" commit="****************************************" />
   </metadata>
 </package>

--- a/test/PackageTests/snapshots/Baselines.Match#manifest.verified.nuspec
+++ b/test/PackageTests/snapshots/Baselines.Match#manifest.verified.nuspec
@@ -12,6 +12,6 @@
     <description>An MSBuild task helper to simplify testing NuGet packages by automatically ensuring the latest package is built and placed in the output directory for test projects.</description>
     <copyright>Copyright 2024. All rights reserved</copyright>
     <tags>NuGet, MSBuild</tags>
-    <repository type="git" url="https://github.com/MattKotsenas/GetPackFromProject.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/MattKotsenas/GetPackFromProject.git" branch="refs/heads/refactor/dotnet-9" commit="****************************************" />
   </metadata>
 </package>


### PR DESCRIPTION
Update SDK to .NET 9 and do related cleanup

- Update NuGet packages
- Migrate to MSTest.Sdk
  - Defer adoption of the new testing platform, as integration tests fail and configuration (i.e. code coverage and TRX reports) don't appear to be plumbed through the same way